### PR TITLE
feat: support ordinal days

### DIFF
--- a/formatting_test.go
+++ b/formatting_test.go
@@ -1,9 +1,10 @@
 package gostradamus
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestParseToTime(t *testing.T) {
@@ -16,6 +17,12 @@ func TestParseToTime_Error(t *testing.T) {
 	actualResult, err := parseToTime("2019-01-01 12:12:12", "YYYY-MM-DD testHH:mm:ss", UTC)
 	assert.Error(t, err)
 	assert.Equal(t, time.Time{}, actualResult)
+}
+
+func TestParseToTimeOrdinal(t *testing.T) {
+	actualResult, err := parseToTime("Tuesday 5th April 2011", "dddd Do MMMM YYYY", UTC)
+	assert.NoError(t, err)
+	assert.Equal(t, time.Date(2011, 4, 5, 0, 0, 0, 0, time.UTC), actualResult)
 }
 
 func TestFormatFromTime(t *testing.T) {
@@ -43,6 +50,18 @@ func TestFormatFromTime(t *testing.T) {
 	assert.Equal(
 		t,
 		"JST +09:00 +0900",
+		actualResult,
+	)
+}
+
+func TestOrdinal(t *testing.T) {
+	actualResult := formatFromTime(
+		time.Date(2011, 4, 5, 15, 7, 8, 9, time.UTC),
+		"dddd Do MMMM YYYY",
+	)
+	assert.Equal(
+		t,
+		"Tuesday 5th April 2011",
 		actualResult,
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require github.com/stretchr/testify v1.7.0
 
 require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/dustin/go-humanize v1.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
As per discussion in issue https://github.com/bykof/gostradamus/issues/4, tried to have a crack at this 

I think this is an imperfect solution - lack of localisation being one such wrinkle, and it's a bit imprecise too, particularly when parsing to a `time.Time` as we also need to replace anything in the input value that uses the `Do` format as this is not a recognised Go format token

Happy to work through with you on this - seemed like a reasonably quick task to complete. Let me know if the approach could be better! :) 